### PR TITLE
Remove warning about Jazzy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,9 @@ ARG ROS_DISTRO=humble
 
 FROM ros:${ROS_DISTRO} as base
 
-RUN apt update && apt install -y ros-${ROS_DISTRO}-pinocchio
+RUN apt update && \
+    apt upgrade -y && \
+    apt install -y ros-${ROS_DISTRO}-pinocchio
 
 RUN mkdir -p /workspace/src
 WORKDIR /workspace

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 This is a basic example of building a ROS 2 package that uses the [Pinocchio](https://github.com/stack-of-tasks/pinocchio) library.
 
-> [!NOTE]
-> Collision checking temporarily does not work on ROS 2 Jazzy, until version 3.4.0 or higher is synced. See https://github.com/stack-of-tasks/pinocchio/issues/2504 for more information.
-
 To run this example:
 
 ```shell


### PR DESCRIPTION
Also snuck in an `apt upgrade` in the Dockerfile to make sure packages are always up to date.